### PR TITLE
chore: add `preferUnplugged` field in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "./tools": "./dist/tools.js",
     "./client": "./dist/client.js"
   },
+  "preferUnplugged": true,
   "scripts": {
     "prepack": "tsc && cp target/wasm32-wasi/release/next_superjson.wasm ./dist",
     "prepare": "husky install"


### PR DESCRIPTION
## Changes
- SWC plugin interface is not allowed when binary in `.zip` archive. (pnp environment)
- Therefore, in order to easily support the yarn pnp environment, it is set to be installed as unplug by default.

## References
- #56 
- https://yarnpkg.com/configuration/manifest#preferUnplugged
